### PR TITLE
Adds Proper AWS Cred Provider Chain

### DIFF
--- a/src/main/kotlin/bot/main/DischordBot.kt
+++ b/src/main/kotlin/bot/main/DischordBot.kt
@@ -1,6 +1,7 @@
 package bot.main
 
 import bot.permissions.BotPermissions
+import com.dischord.provider.BotTokenProvider
 import dev.kord.common.annotation.KordPreview
 import dev.kord.gateway.Intents
 import kotlinx.coroutines.flow.toList
@@ -14,12 +15,12 @@ import javax.inject.Named
 
 
 class DischordBot @Inject constructor(
-    @Named("BotToken") private val botToken: String,
+    @Named("BotTokenProvider") private val botTokenProvider: BotTokenProvider,
 ) {
 
     @OptIn(KordPreview::class)
     suspend fun startBot() {
-        bot(botToken) {
+        bot(botTokenProvider.getDiscordBotToken()) {
             prefix {
                 "?"
             }

--- a/src/main/kotlin/com/dischord/dagger/Config.kt
+++ b/src/main/kotlin/com/dischord/dagger/Config.kt
@@ -1,18 +1,18 @@
 package com.dischord.dagger
 
+import aws.sdk.kotlin.services.secretsmanager.SecretsManagerClient
+import com.dischord.provider.BotTokenProvider
 import dagger.Module
 import dagger.Provides
-import io.github.cdimascio.dotenv.dotenv
 import javax.inject.Named
 import javax.inject.Singleton
 
-@Module
+@Module(includes = [DependencyModule::class])
 class Config {
     @Provides
     @Singleton
-    @Named("BotToken")
-    fun botToken(): String {
-        val dotenv = dotenv()
-        return dotenv["BOT_TOKEN"]
+    @Named("BotTokenProvider")
+    fun botTokenProvider(client: SecretsManagerClient): BotTokenProvider {
+        return BotTokenProvider(client)
     }
 }

--- a/src/main/kotlin/com/dischord/dagger/DependencyModule.kt
+++ b/src/main/kotlin/com/dischord/dagger/DependencyModule.kt
@@ -1,7 +1,6 @@
 package com.dischord.dagger
 
 import aws.sdk.kotlin.services.secretsmanager.SecretsManagerClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProviderChain
 import dagger.Module
 import dagger.Provides
 import io.ktor.client.HttpClient
@@ -20,14 +19,7 @@ class DependencyModule {
 
     @Provides
     @Singleton
-    fun createSecretsManagerClient(credentialsProviderChain: CredentialsProviderChain): SecretsManagerClient {
-        return SecretsManagerClient {
-            credentialsProvider = credentialsProviderChain
-        }
-    }
-
-    @Provides
-    fun createAwsCredentialsProvider(): CredentialsProviderChain {
-        return CredentialsProviderChain()
+    fun createSecretsManagerClient(): SecretsManagerClient {
+        return SecretsManagerClient {}
     }
 }

--- a/src/main/kotlin/com/dischord/provider/BotTokenProvider.kt
+++ b/src/main/kotlin/com/dischord/provider/BotTokenProvider.kt
@@ -1,0 +1,23 @@
+package com.dischord.provider
+
+import aws.sdk.kotlin.services.secretsmanager.SecretsManagerClient
+import aws.sdk.kotlin.services.secretsmanager.model.GetSecretValueRequest
+import io.github.cdimascio.dotenv.dotenv
+import javax.inject.Inject
+
+class BotTokenProvider @Inject constructor(
+    private val secretsManagerClient: SecretsManagerClient
+) {
+    suspend fun getDiscordBotToken(): String {
+        val dotenv = dotenv()
+        return dotenv["BOT_TOKEN"] ?: getTokenFromAws()
+    }
+
+    private suspend fun getTokenFromAws(): String {
+        val request = GetSecretValueRequest {
+            secretId = "DiscordBotKey"
+        }
+        return secretsManagerClient.getSecretValue(request).secretString
+            ?: throw RuntimeException("Unable to fetch Discord API Key from secrets manager")
+    }
+}


### PR DESCRIPTION
Updates the SecretsManager Dagger stuff to use the proper AWS cred provider and refactors bot token retrieval to first check for the token in .env and then falling back to AWS Secrets Manager.